### PR TITLE
Mask environment value

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,12 +13,12 @@ async function getSecretValue (secretsManager, secretName) {
 }
 
 getSecretValue(secretsManager, secretName).then(resp => {
-  core.setSecret(resp.SecretString)
   const secret = resp.SecretString
 
   if (secret) {
     const parsedSecret = JSON.parse(secret)
     Object.entries(parsedSecret).forEach(([key, value]) => {
+      core.setSecret(value)
       core.exportVariable(key, value)
     })
   } else {


### PR DESCRIPTION
## Story

* As @brunocascio says that env values is not masked. So it can be revealed out like this below image. https://github.com/say8425/aws-secrets-manager-actions/issues/8
<img width="380" alt="스크린샷 2019-11-25 오후 3 03 15" src="https://user-images.githubusercontent.com/3258867/69516366-c735f500-0f94-11ea-8f81-af79efcf8264.png">

## Solving

* [setSecret](https://github.com/actions/toolkit/blob/master/packages/core/src/core.ts#L47) method, can mask these values.
* So this PR will mask all env values, so values dose not revealed any more.
<img width="350" alt="스크린샷 2019-11-25 오후 3 02 38" src="https://user-images.githubusercontent.com/3258867/69516370-ca30e580-0f94-11ea-8983-6fef111969fc.png">

