### PR TITLE
Fix drafter action

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -5,6 +5,7 @@ categories:
       - 'feature'
   - title: '🛠 Fixes'
     label:
+      - 'fix'
       - 'bug'
   - title: '🧰 Maintenance'
     label:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,10 +1,10 @@
 name-template: 'v$NEXT_PATCH_VERSION 🌈'
 categories:
   - title: '🚀 Features'
-    labels:
+    label:
       - 'feature'
   - title: '🛠 Fixes'
-    labels:
+    label:
       - 'bug'
   - title: '🧰 Maintenance'
     label:


### PR DESCRIPTION
## Story

* I copy and paste from release-drafter example. But this example had a deprecated syntax. So it cause [errors](https://github.com/say8425/aws-secrets-manager-actions/commit/963733ee3505a8949ded7d6501bafde31f0ebcf8/checks?check_suite_id=357019025).

## Solve

* use `label` instead of `labels`.

## Extra

* add fix label for fix category.

## References

* https://github.com/release-drafter/release-drafter/issues/320#issuecomment-552233154