### PR TITLE
Fix relase workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - master
 jobs:
-  update_release_draft:
+  release-draft:
     runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v5.3.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ on:
   release:
     types: [published]
 jobs:
-  release github:
+  release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Story

* GitHub Action job has a [rule](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#jobsjob_id) name **should not have white space**.

## Done

* remove white space
* rename creating release draft workflow