### PR TITLE
Fix release drafter label

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,18 +1,18 @@
 name-template: 'v$NEXT_PATCH_VERSION'
 categories:
-  - title: 'Features'
+  - title: '⚡️ Features'
     labels:
-      - 'feature'
-  - title: 'Fixes'
+      - '⚡️ feature'
+  - title: '🛠 Fixes'
     labels:
-      - 'fix'
-      - 'bug'
-  - title: 'Maintenance'
+      - '🐛 bug'
+      - '🚨 security'
+  - title: '⚙️ Maintenance'
     labels:
-      - 'dependencies'
-      - 'docs'
-      - 'ci'
-      - 'refactor'
+      - '📦 dependencies'
+      - '📄 docs'
+      - '🏭 ci'
+      - '⚙️ refactor'
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR '
 template: |
   $CHANGES


### PR DESCRIPTION
## Story

* [label](https://github.com/say8425/aws-secrets-manager-actions/labels) names were changed.
* So our release-drafter action could not detect labels.

## Solves

* Sync `.github/release-drafter.yml` with these new labels.

## References

* https://github.com/release-drafter/release-drafter
