### PR TITLE
Fix release gh action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,8 +14,15 @@ jobs:
           node-version: '12.x'
       - name: Install Packages
         run: yarn install
-      - name: Bump package Version
-        run: npm version --message "Bump v%s" --new-version from-git
+      - name: Bump new Package Version
+        run: npm version --new-version ${{ github.event.release.tag_name }} -no-git-tag-version
+      - name: Commit new Package Version
+        uses: EndBug/add-and-commit@v5
+        with:
+          message: 'ci: Bump ${{ github.event.release.tag_name }}'
+          add: 'package.json'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Release to GitHub Actions Market
         uses: technote-space/release-github-actions@v6
         with:


### PR DESCRIPTION
## Story

* Release Action was being failed.
  * https://github.com/say8425/aws-secrets-manager-actions/actions/runs/174459173
* Cuz `npm version --message "Bump v%s" --new-version from-git` command was added into GitHub Action https://github.com/say8425/aws-secrets-manager-actions/commit/4f15b7d5c8a66d7ef0b03775ed6cc66a48066bbc
  * **from-git** option catch tag from current branch
  * But our repo's **master** branch dose not have any [tags](https://github.com/say8425/aws-secrets-manager-actions/tags) but **gh-actions** branch has it.
  * So it dose not work.

## Solves

* run npm version with **-no-git-tag-version**
  * this option dose not run git commit and tag
  * But still has changes.
  * And we should commit this changes.
* Run git commit with [Add & Commit action](https://github.com/EndBug/add-and-commit)

## References

* [npm cli version](https://docs.npmjs.com/cli/version.html)
* [Add & Commit action](https://github.com/EndBug/add-and-commit)
