### PR TITLE
Dependent/action 1.2.6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,5 @@ package-lock.json
 
 # asdf nodejs version
 .tool-versions
+
+dist

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/say8425/aws-secrets-manager-actions",
   "dependencies": {
-    "@actions/core": "^1.2.4",
+    "@actions/core": "^1.2.6",
     "aws-sdk": "^2.668.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@actions/core@^1.2.4":
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.4.tgz#96179dbf9f8d951dd74b40a0dbd5c22555d186ab"
-  integrity sha512-YJCEq8BE3CdN8+7HPZ/4DxJjk/OkZV2FFIf+DlZTC/4iBlzYCD5yjRR6eiOS5llO11zbRltIRuKAjMKaWTE6cg==
+"@actions/core@^1.2.6":
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.6.tgz#a78d49f41a4def18e88ce47c2cac615d5694bf09"
+  integrity sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA==
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.10.4"


### PR DESCRIPTION
## Story

* `set-env` will be deprecated from GH Action.
* Of course, we didn't use it. But our builded output use it.
* So we should upgrade GH core version not to use it.

## Solves

* Upgrade GH 1.2.6
* And gitignore build output

## References

* https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
* https://github.com/say8425/aws-secrets-manager-actions/pull/34
