### PR TITLE
Fix releasing github registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           registry: 'https://npm.pkg.github.com'
+          access:  ${{ format('@{0}', github.repository_owner) }}
       - name: Release to GitHub Actions Market
         uses: technote-space/release-github-actions@v6
         with:


### PR DESCRIPTION
## Story

* GitHub registry needs a scope option

## Solves

* Use NPM Publish action's access option for scope

## References

* https://docs.github.com/en/free-pro-team@latest/actions/guides/publishing-nodejs-packages#publishing-packages-to-github-packages
* https://github.com/JS-DevTools/npm-publish/commit/a6d76a18a18f0e733ec4592bfd46f55f333d8cc3