### PR TITLE
Remove releasing GitHub registry

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         uses: technote-space/package-version-check-action@v1
         with:
           COMMIT_DISABLED: 1
-      - name: Rlease to NPM Registry
+      - name: Release to NPM Registry
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,12 +32,6 @@ jobs:
         uses: JS-DevTools/npm-publish@v1
         with:
           token: ${{ secrets.NPM_TOKEN }}
-      - name: Rlease to GitHub Registry
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          registry: 'https://npm.pkg.github.com'
-          access:  ${{ format('@{0}', github.repository_owner) }}
       - name: Release to GitHub Actions Market
         uses: technote-space/release-github-actions@v6
         with:


### PR DESCRIPTION
## Story

```Error: Error: Unable to determine the current version of aws-secrets-manager-actions on NPM. 
npm view aws-secrets-manager-actions version exited with a status of 1.
npm ERR! code E404
npm ERR! 404 'aws-secrets-manager-actions' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it
npm ERR! 404 (or use the name yourself!)
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
npm ERR! 404 
npm ERR! 404  'aws-secrets-manager-actions@latest' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2020-12-20T10_21_04_628Z-debug.log
    at Object.getLatestVersion (/home/runner/work/_actions/JS-DevTools/npm-publish/v1/src/npm.ts:57:13)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
ProcessError: npm view aws-secrets-manager-actions version exited with a status of 1.
npm ERR! code E404
npm ERR! 404 'aws-secrets-manager-actions' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it
npm ERR! 404 (or use the name yourself!)
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
npm ERR! 404 
npm ERR! 404  'aws-secrets-manager-actions@latest' is not in the npm registry.
npm ERR! 404 You should bug the author to publish it (or use the name yourself!)
npm ERR! 404 
npm ERR! 404 Note that you can also install from a
npm ERR! 404 tarball, folder, http url, or git url.
npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2020-12-20T10_21_04_628Z-debug.log
    at normalizeResult (/home/runner/work/_actions/JS-DevTools/npm-publish/v1/node_modules/@jsdevtools/ez-spawn/lib/normalize-result.js:31:1)
    at ChildProcess.<anonymous> (/home/runner/work/_actions/JS-DevTools/npm-publish/v1/node_modules/@jsdevtools/ez-spawn/lib/async.js:79:1)
    at ChildProcess.emit (events.js:210:5)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:272:12)
```

* Release to GitHub registry with [NPM Publish Action](https://github.com/pascalgn/npm-publish-action) has been raise an error. I give up release to GitHub registry.

## Solves

* Remove releasing GitHub registry.

## References

* https://github.com/say8425/aws-secrets-manager-actions/runs/1338353950?check_suite_focus=true
* https://github.com/say8425/aws-secrets-manager-actions/runs/1584302728?check_suite_focus=true
