### PR TITLE
Add cache condtion and gh test jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,36 +3,136 @@ on:
   release:
     types: [published]
 jobs:
-  release:
+  install-dependencies:
+    if: contains(github.event.head_commit.message, 'skip ci') == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Setup nodejs
+      - name: Setup node.js
         uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - name: Get Yarn Cache Directory
+      - name: Set yarn cache directory path
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: Cache node dependencies
+      - name: Restore dependencies from cache
         uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - name: Install Packages
-        run: yarn install
+      - name: Install dependencies
+        run: yarn --prefer-offline
+  check-package-version:
+    runs-on: ubuntu-latest
+    needs:
+      - install-dependencies
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Set yarn cache directory path
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Restore dependencies from cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: yarn --prefer-offline
       - name: Check package version
         uses: technote-space/package-version-check-action@v1
         with:
           COMMIT_DISABLED: 1
-      - name: Release to NPM Registry
-        uses: JS-DevTools/npm-publish@v1
+  release-npm:
+    runs-on: ubuntu-latest
+    needs:
+      - check-package-version
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup node.js
+        uses: actions/setup-node@v1
         with:
-          token: ${{ secrets.NPM_TOKEN }}
-      - name: Release to GitHub Actions Market
+          node-version: '12.x'
+      - name: Set yarn cache directory path
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Restore dependencies from cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: yarn --prefer-offline
+      - name: Release to NPM
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  release-github-package:
+    runs-on: ubuntu-latest
+    needs:
+      - check-package-version
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup node.js for GitHub Packages
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          registry-url: 'https://npm.pkg.github.com'
+          scope: '@say8425'
+      - name: Set yarn cache directory path
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Restore dependencies from cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: yarn --prefer-offline
+      - name: Release to GitHub Packages
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  release-github-actions:
+    runs-on: ubuntu-latest
+    needs:
+      - release-npm
+      - release-github-package
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Set yarn cache directory path
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Restore dependencies from cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: yarn --prefer-offline
+      - name: Release to GitHub Actions
         uses: technote-space/release-github-actions@v6
         with:
           PACKAGE_MANAGER: yarn

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,3 +137,41 @@ jobs:
         with:
           PACKAGE_MANAGER: yarn
           BUILD_COMMAND: yarn package
+  test-github-actions:
+    runs-on: ubuntu-latest
+    needs:
+      - install-dependencies
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Set yarn cache directory path
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Restore dependencies from cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: yarn --prefer-offline
+      - name: Package
+        run: yarn package
+      - name: Use AWS Secrets Manager Actions from current branch
+        uses: ./
+        with:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          SECRET_NAME: ${{ secrets.SECRET_NAME }}
+      - name: Should have SCIENTIFIC_NAME
+        uses: therussiankid92/gat
+        with:
+          assertion: should.equal
+          expected: Pygoscelis adeliae
+          actual: ${{ env.SCIENTIFIC_NAME }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,27 +7,51 @@ on:
     branches:
       - master
 jobs:
-  test:
+  install-dependencies:
+    if: contains(github.event.head_commit.message, 'skip ci') == false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Setup nodejs
+      - name: Setup node.js
         uses: actions/setup-node@v1
         with:
           node-version: '12.x'
-      - name: Get Yarn Cache Directory
+      - name: Set yarn cache directory path
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: Cache node dependencies
+      - name: Restore dependencies from cache
         uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-      - name: Install Packages
-        run: yarn install
+      - name: Install dependencies
+        run: yarn --prefer-offline
+  test:
+    runs-on: ubuntu-latest
+    needs:
+      - install-dependencies
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Set yarn cache directory path
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Restore dependencies from cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: yarn --prefer-offline
       - name: Run Test
         run: yarn test
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,3 +60,41 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_DEFAULT_OUTPUT: ${{ secrets.AWS_DEFAULT_OUTPUT }}
+  test-github-actions:
+    runs-on: ubuntu-latest
+    needs:
+      - install-dependencies
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+      - name: Set yarn cache directory path
+        id: yarn-cache
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+      - name: Restore dependencies from cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+      - name: Install dependencies
+        run: yarn --prefer-offline
+      - name: Package
+        run: yarn package
+      - name: Use AWS Secrets Manager Actions from current branch
+        uses: ./
+        with:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          SECRET_NAME: ${{ secrets.SECRET_NAME }}
+      - name: Should have SCIENTIFIC_NAME
+        uses: therussiankid92/gat@v1
+        with:
+          assertion: should.equal
+          expected: Pygoscelis adeliae
+          actual: ${{ env.SCIENTIFIC_NAME }}


### PR DESCRIPTION
## Story

* Testing a released gh action is too difficult.
* Jobs are too big.
* Installing dependencies are always running.

## Solves

* Use [Github Action Test Automation](https://github.com/marketplace/actions/github-action-test-automation).
  * Test current branch by using [current action.yml](https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/finding-and-customizing-actions#referencing-an-action-in-the-same-repository-where-a-workflow-file-uses-the-action).
  * `uses: ./`
* Separate a job to multiple jobs.
* ~~Use [cache-hit](https://github.com/actions/cache#skipping-steps-based-on-cache-hit) option.~~
  * Use [yarn --prefer-offline](https://github.com/yarnpkg/yarn/blob/v0.24.2/src/cli/index.js#L36).

## In Addition

> The workflow is not valid. .github/workflows/test.yml (Line: 89, Col: 15): Unrecognized named-value: 'github'. Located at position 1 within expression: github.action_path
> https://github.com/say8425/aws-secrets-manager-actions/actions/runs/446727841

* `uses: ${{ github.action_path }}` looks best, but [uses]() looks not allow [contexts](https://docs.github.com/en/free-pro-team@latest/actions/reference/context-and-expression-syntax-for-github-actions#contexts).

## References

* [SO: How to cache yarn packages in GitHub Actions](https://stackoverflow.com/a/62244232/3910390)
* [GH Actions Docs: jobs.<job_id>.steps[*].uses](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsuses)
* [Github Action Test Automation](https://github.com/therussiankid92/gat)
