### PR TITLE
update example for version 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This GitHub Action helps you define your secrets that stored in [AWS Secrets Man
 ```yaml
 steps:
  - name: Store ENV from AWS SecretManager
-   uses: say8425/aws-secrets-manager-actions@v1
+   uses: say8425/aws-secrets-manager-actions@v2
    with:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Story

* [Version 2](https://github.com/say8425/aws-secrets-manager-actions/releases/tag/v2.0.0) was released. But usage example still use version 1 

## Solves

* update example `v1` -> `v2`
