### PR TITLE
feature: Github Openid connect actions support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,20 @@ This GitHub Action helps you define your secrets that stored in [AWS Secrets Man
 
 ## Usage
 
+## 1. Using github [openid-connect](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services) (Recommented)
+
+```yaml
+steps:
+ - name: Store ENV from AWS SecretManager
+   uses: say8425/aws-secrets-manager-actions@v2
+   with:
+     AWS_DEFAULT_REGION: "YOUR-AWS-REGION"
+     SECRET_NAME: ${{ env.SECRET_NAME }}
+     OUTPUT_PATH: '.env' # optional
+```
+
+## 2. Using github secrets
+
 ```yaml
 steps:
  - name: Store ENV from AWS SecretManager

--- a/action.yml
+++ b/action.yml
@@ -6,13 +6,16 @@ inputs:
     required: true
   AWS_ACCESS_KEY_ID:
     description: 'Set Aws Access Key ID'
-    required: true
+    required: false
   AWS_SECRET_ACCESS_KEY:
     description: 'Set Aws Secret access Key'
-    required: true
+    required: false
+  AWS_SESSION_TOKEN:
+    description: 'Set Aws Session token Key'
+    required: false
   AWS_DEFAULT_REGION:
     description: 'Set Aws default region'
-    required: true
+    required: false
   OUTPUT_PATH:
     description: 'Set output file where variables are write'
     required: false

--- a/index.js
+++ b/index.js
@@ -1,15 +1,21 @@
-const core = require('@actions/core')
-const aws = require('aws-sdk')
+import * as core from '@actions/core'
+import { SecretsManager } from 'aws-sdk'
 const fs = require('fs')
 
 const outputPath = core.getInput('OUTPUT_PATH')
 const secretName = core.getInput('SECRET_NAME')
 
-const secretsManager = new aws.SecretsManager({
-  accessKeyId: core.getInput('AWS_ACCESS_KEY_ID'),
-  secretAccessKey: core.getInput('AWS_SECRET_ACCESS_KEY'),
-  region: core.getInput('AWS_DEFAULT_REGION')
-})
+const AWSConfig = {
+  accessKeyId: core.getInput('AWS_ACCESS_KEY_ID') || process.env.AWS_ACCESS_KEY_ID,
+  secretAccessKey: core.getInput('AWS_SECRET_ACCESS_KEY') || process.env.AWS_SECRET_ACCESS_KEY,
+  region: core.getInput('AWS_DEFAULT_REGION') || process.env.AWS_DEFAULT_REGION
+}
+
+if (core.getInput('AWS_SESSION_TOKEN') || process.env.AWS_SESSION_TOKEN) {
+  AWSConfig.sessionToken = core.getInput('AWS_SESSION_TOKEN') || process.env.AWS_SESSION_TOKEN
+}
+
+const secretsManager = new SecretsManager(AWSConfig)
 
 async function getSecretValue (secretsManager, secretName) {
   return secretsManager.getSecretValue({ SecretId: secretName }).promise()

--- a/index.test.js
+++ b/index.test.js
@@ -6,11 +6,17 @@ describe('get SecretString from AWS SecretsManager', () => {
   describe('get parsable data', () => {
     beforeAll(async () => {
       const INPUT_SECRET_NAME = process.env.SECRET_NAME
-      const secretsManager = new aws.SecretsManager({
+      const AWSConfig = {
         accessKeyId: process.env.AWS_ACCESS_KEY_ID,
         secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
         region: process.env.AWS_DEFAULT_REGION
-      })
+      }
+
+      if (process.env.AWS_SESSION_TOKEN) {
+        AWSConfig.sessionToken = process.env.AWS_SESSION_TOKEN
+      }
+
+      const secretsManager = new aws.SecretsManager(AWSConfig)
       data = await index.getSecretValue(secretsManager, INPUT_SECRET_NAME)
     })
 

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
   },
   "homepage": "https://github.com/say8425/aws-secrets-manager-actions",
   "dependencies": {
-    "@actions/core": "^1.2.6",
-    "aws-sdk": "^2.668.0"
+    "@actions/core": "^1.6.0",
+    "aws-sdk": "^2.1070.0"
   },
   "devDependencies": {
     "@zeit/ncc": "^0.22.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,19 @@
 # yarn lockfile v1
 
 
-"@actions/core@^1.2.6":
-  version "1.2.6"
-  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.2.6.tgz#a78d49f41a4def18e88ce47c2cac615d5694bf09"
-  integrity sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA==
+"@actions/core@^1.6.0":
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/@actions/core/-/core-1.6.0.tgz#0568e47039bfb6a9170393a73f3b7eb3b22462cb"
+  integrity sha512-NB1UAZomZlCV/LmJqkLhNTqtKfFXJZAUPcfl/zqG7EfsQdeUJtaWO98SGbuQ3pydJ3fHl2CvI/51OKYlCYYcaw==
+  dependencies:
+    "@actions/http-client" "^1.0.11"
+
+"@actions/http-client@^1.0.11":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@actions/http-client/-/http-client-1.0.11.tgz#c58b12e9aa8b159ee39e7dd6cbd0e91d905633c0"
+  integrity sha512-VRYHGQV1rqnROJqdMvGUbY/Kn8vriQe/F9HR2AlYHzmKuM/p3kjNuXhmdBfcVgsvRWTz5C5XW5xvndZrVBuAYg==
+  dependencies:
+    tunnel "0.0.6"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.10.4"
@@ -774,15 +783,15 @@ atob@^2.1.2:
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.2.tgz#6d9517eb9e030d2436666651e86bd9f6f13533c9"
   integrity sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
 
-aws-sdk@^2.668.0:
-  version "2.715.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.715.0.tgz#b890892098e0a4d9e7189ed341267d4a9a6e856b"
-  integrity sha512-O6ytb66IXFCowp0Ng2bSPM6v/cZVOhjJWFTR1CG4ieG4IroAaVgB3YQKkfPKA0Cy9B/Ovlsm7B737iuroKsd0w==
+aws-sdk@^2.1070.0:
+  version "2.1070.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1070.0.tgz#e7a27c34ed3a92776aa9128ed3469cb94bba9655"
+  integrity sha512-tkmuycoJ9k0qF1iq03iqyhevxP3l0OlrnUxjd0x8nZ9Ko1TGjyj0yJS4Vbd4r5RBpKUwRqedB7TAyZ/71mcZKw==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
     ieee754 "1.1.13"
-    jmespath "0.15.0"
+    jmespath "0.16.0"
     querystring "0.2.0"
     sax "1.2.1"
     url "0.10.3"
@@ -2630,10 +2639,10 @@ jest@^26.1.0:
     import-local "^3.0.2"
     jest-cli "^26.1.0"
 
-jmespath@0.15.0:
-  version "0.15.0"
-  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.15.0.tgz#a3f222a9aae9f966f5d27c796510e28091764217"
-  integrity sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=
+jmespath@0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/jmespath/-/jmespath-0.16.0.tgz#b15b0a85dfd4d930d43e69ed605943c802785076"
+  integrity sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==
 
 js-tokens@^4.0.0:
   version "4.0.0"
@@ -4045,6 +4054,11 @@ tunnel-agent@^0.6.0:
   integrity sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
   dependencies:
     safe-buffer "^5.0.1"
+
+tunnel@0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/tunnel/-/tunnel-0.0.6.tgz#72f1314b34a5b192db012324df2cc587ca47f92c"
+  integrity sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==
 
 tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"


### PR DESCRIPTION
## Story

Why did you create this pull request?

Support for github openid connect actions, as it the best and secure was for use aws creds in github actions

## Solves

check precess.env for aws creds as session token
What dose this change?

## References
https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
Do you have any references? (eg. MDN, Stackoverflow)
