### PR TITLE
Upgrade node.js 12 -> 16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,7 @@ inputs:
     description: 'Set output file where variables are write'
     required: false
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'
 branding:
   icon: 'lock'


### PR DESCRIPTION
## Story

* node.js 12 was deprecated

## Solves

* use node.js 16

## References

* https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs-for-javascript-actions
* fix https://github.com/say8425/aws-secrets-manager-actions/issues/129
